### PR TITLE
Retry on load

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -31,4 +31,4 @@ RUN apk add --update curl py-psutil jq python python-dev py-pip build-base && \
 
 RUN pip install Jinja2
 
-ENTRYPOINT /usr/local/bin/run.sh
+ENTRYPOINT ["/usr/local/bin/run.sh"]

--- a/build-dev.sh
+++ b/build-dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+os=$1
+org=${2:-"hyperpilot"}
+
+cmd="docker build -t ${org}/snap:${os}-init_dev \
+  --build-arg BUILD_DATE=$(date +%Y-%m-%d)"
+
+${cmd} -f "${os}/Dockerfile" .

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,26 @@
 #!/bin/sh
-
 /usr/local/bin/init_snap
 
-python snap_init.py --config $1
+echo "args: $@"
 
-# Start Snap daemon
-snapteld --plugin-load-timeout 15 -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o '' &
-SNAP_PID=$(pidof snapteld)
+# Start Snapteld in background job
+echo "Starting snaptel deamon in background"
+snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} -o '' &
 
-wait $SNAP_PID
+# Start Snap_init.py in foreground job
+echo "Starting python in foreground"
+python snap_init.py --config $1 
+exit_status=$?
+echo "exit status: $exit_status"
+
+# Check exit status
+if [ $exit_status -ne "0" ]
+	then
+	exit 1 # Unable to load plugin OR create tasks after trials. Let k8s to restart this pod
+fi
+echo "Plugins are sucessfully loaded"
+echo "Tasks are sucessfully created"
+
+ps -l
+echo $(pidof snapteld)
+wait $(pidof snapteld)

--- a/run.sh
+++ b/run.sh
@@ -16,11 +16,9 @@ echo "exit status: $exit_status"
 # Check exit status
 if [ $exit_status -ne "0" ]
 	then
-	exit 1 # Unable to load plugin OR create tasks after trials. Let k8s to restart this pod
+	exit 1 # Unable to load plugin OR create tasks after trialsche. Let k8s to restart this pod
 fi
 echo "Plugins are sucessfully loaded"
 echo "Tasks are sucessfully created"
 
-ps -l
-echo $(pidof snapteld)
 wait $(pidof snapteld)

--- a/snapteld.conf
+++ b/snapteld.conf
@@ -29,7 +29,7 @@ log_level: 2
 control:
   # auto_discover_path sets the directory(s) to auto load plugins and tasks on
   # the start of the snap daemon. This can be a comma separated list of directories.
-  auto_discover_path: /opt/snap/plugins:/opt/snap/tasks
+  # auto_discover_path: /opt/snap/plugins:/opt/snap/tasks
 
   # cache_expiration sets the time interval for the plugin cache to use before
   # expiring collection results from collect plugins. Default value is 500ms

--- a/snapteld.conf
+++ b/snapteld.conf
@@ -29,7 +29,7 @@ log_level: 2
 control:
   # auto_discover_path sets the directory(s) to auto load plugins and tasks on
   # the start of the snap daemon. This can be a comma separated list of directories.
-  auto_discover_path: /opt/snap/plugins:/opt/snap/tasks
+  # auto_discover_path: /opt/snap/tasks
 
   # cache_expiration sets the time interval for the plugin cache to use before
   # expiring collection results from collect plugins. Default value is 500ms
@@ -74,7 +74,10 @@ control:
 
   # plugins section contains plugin config settings that will be applied for
   # plugins across tasks.
-  # plugins:
+  plugins:
+    all:
+      mx4j_url: kafka-serve.default
+      mx4j_port: 8082
 
 # scheduler configuration settings contains all settings for scheduler
 # module

--- a/snapteld.conf
+++ b/snapteld.conf
@@ -29,7 +29,7 @@ log_level: 2
 control:
   # auto_discover_path sets the directory(s) to auto load plugins and tasks on
   # the start of the snap daemon. This can be a comma separated list of directories.
-  # auto_discover_path: /opt/snap/tasks
+  auto_discover_path: /opt/snap/plugins:/opt/snap/tasks
 
   # cache_expiration sets the time interval for the plugin cache to use before
   # expiring collection results from collect plugins. Default value is 500ms
@@ -74,10 +74,7 @@ control:
 
   # plugins section contains plugin config settings that will be applied for
   # plugins across tasks.
-  plugins:
-    all:
-      mx4j_url: kafka-serve.default
-      mx4j_port: 8082
+  # plugins:
 
 # scheduler configuration settings contains all settings for scheduler
 # module


### PR DESCRIPTION
### Changes

* snap_init.py is responsible for loading plugin/creating tasks, instead of auto discovery

Support retry when loading plugin.
#### Expected behaivor:

If snap_init.py exit status not 0 (i.e. plugin not loaded or tasks not created successfully), entrypoint script will exit, letting kubernetes to restart this pod. Otherwise, the control is given to snapteld.